### PR TITLE
[IMP] being able to customize context when running reports

### DIFF
--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -232,6 +232,9 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
     def compute_balance_data(self, data, filter_report_type=None):
         lang = self.localcontext.get('lang')
         lang_ctx = lang and {'lang': lang} or {}
+
+        lang_ctx.update(self._get_customized_context(data))
+
         new_ids = data['form']['account_ids'] or data[
             'form']['chart_account_id']
         max_comparison = self._get_form_param(

--- a/account_financial_report_webkit/report/common_balance_reports.py
+++ b/account_financial_report_webkit/report/common_balance_reports.py
@@ -117,7 +117,7 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
         return accounts_by_id
 
     def _get_comparison_details(self, data, account_ids, target_move,
-                                comparison_filter, index):
+                                comparison_filter, index, context=None):
         """
 
         @param data: data of the wizard form
@@ -154,7 +154,7 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
                 and self._get_initial_balance_mode(start) or False
             accounts_by_ids = self._get_account_details(
                 account_ids, target_move, fiscalyear, details_filter,
-                start, stop, initial_balance_mode)
+                start, stop, initial_balance_mode, context=context)
             comp_params = {
                 'comparison_filter': comparison_filter,
                 'fiscalyear': fiscalyear,
@@ -230,6 +230,8 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
         return start_period, stop_period, start, stop
 
     def compute_balance_data(self, data, filter_report_type=None):
+        lang = self.localcontext.get('lang')
+        lang_ctx = lang and {'lang': lang} or {}
         new_ids = data['form']['account_ids'] or data[
             'form']['chart_account_id']
         max_comparison = self._get_form_param(
@@ -265,20 +267,22 @@ class CommonBalanceReportHeaderWebkit(CommonReportHeaderWebkit):
         # get details for each accounts, total of debit / credit / balance
         accounts_by_ids = self._get_account_details(
             account_ids, target_move, fiscalyear, main_filter, start, stop,
-            initial_balance_mode)
+            initial_balance_mode, context=lang_ctx)
 
         comparison_params = []
         comp_accounts_by_ids = []
         for index in range(max_comparison):
             if comp_filters[index] != 'filter_no':
                 comparison_result, comp_params = self._get_comparison_details(
-                    data, account_ids, target_move, comp_filters[index], index)
+                    data, account_ids, target_move, comp_filters[index], index,
+                    context=lang_ctx)
                 comparison_params.append(comp_params)
                 comp_accounts_by_ids.append(comparison_result)
 
         objects = self.pool.get('account.account').browse(self.cursor,
                                                           self.uid,
-                                                          account_ids)
+                                                          account_ids,
+                                                          context=lang_ctx)
 
         to_display_accounts = dict.fromkeys(account_ids, True)
         init_balance_accounts = dict.fromkeys(account_ids, False)

--- a/account_financial_report_webkit/report/common_partner_balance_reports.py
+++ b/account_financial_report_webkit/report/common_partner_balance_reports.py
@@ -222,6 +222,9 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
     def compute_partner_balance_data(self, data, filter_report_type=None):
         lang = self.localcontext.get('lang')
         lang_ctx = lang and {'lang': lang} or {}
+
+        lang_ctx.update(self._get_customized_context(data))
+
         new_ids = data['form']['account_ids'] or data[
             'form']['chart_account_id']
         max_comparison = self._get_form_param(

--- a/account_financial_report_webkit/report/common_partner_balance_reports.py
+++ b/account_financial_report_webkit/report/common_partner_balance_reports.py
@@ -220,6 +220,8 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
         return accounts_details_by_ids, comp_params
 
     def compute_partner_balance_data(self, data, filter_report_type=None):
+        lang = self.localcontext.get('lang')
+        lang_ctx = lang and {'lang': lang} or {}
         new_ids = data['form']['account_ids'] or data[
             'form']['chart_account_id']
         max_comparison = self._get_form_param(
@@ -259,7 +261,7 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
         # get details for each accounts, total of debit / credit / balance
         accounts_by_ids = self._get_account_details(
             account_ids, target_move, fiscalyear, main_filter, start, stop,
-            initial_balance_mode)
+            initial_balance_mode, context=lang_ctx)
 
         partner_details_by_ids = self._get_account_partners_details(
             accounts_by_ids, main_filter, target_move, start, stop,
@@ -280,7 +282,8 @@ class CommonPartnerBalanceReportHeaderWebkit(CommonBalanceReportHeaderWebkit,
                 comp_accounts_by_ids.append(comparison_result)
         objects = self.pool.get('account.account').browse(self.cursor,
                                                           self.uid,
-                                                          account_ids)
+                                                          account_ids,
+                                                          context=lang_ctx)
 
         init_balance_accounts = {}
         comparisons_accounts = {}

--- a/account_financial_report_webkit/report/common_reports.py
+++ b/account_financial_report_webkit/report/common_reports.py
@@ -39,9 +39,14 @@ class CommonReportHeaderWebkit(common_report_header):
     """Define common helper for financial report"""
 
     ######################################################################
+    # context customizer                                                 #
+    ######################################################################
+    def _get_customized_context(self, data):
+        return {}
+
+    ######################################################################
     # From getter helper                                                 #
     ######################################################################
-
     def get_start_period_br(self, data):
         return self._get_info(data, 'period_from', 'account.period')
 

--- a/account_financial_report_webkit/report/general_ledger.py
+++ b/account_financial_report_webkit/report/general_ledger.py
@@ -75,6 +75,8 @@ class GeneralLedgerWebkit(report_sxw.rml_parse, CommonReportHeaderWebkit):
     def set_context(self, objects, data, ids, report_type=None):
         """Populate a ledger_lines attribute on each browse record that will be
         used by mako template"""
+        lang = self.localcontext.get('lang')
+        lang_ctx = lang and {'lang': lang} or {}
         new_ids = data['form']['account_ids'] or data[
             'form']['chart_account_id']
 
@@ -121,7 +123,8 @@ class GeneralLedgerWebkit(report_sxw.rml_parse, CommonReportHeaderWebkit):
             stop)
         objects = self.pool.get('account.account').browse(self.cursor,
                                                           self.uid,
-                                                          accounts)
+                                                          accounts,
+                                                          context=lang_ctx)
 
         init_balance = {}
         ledger_lines = {}

--- a/account_financial_report_webkit/report/general_ledger.py
+++ b/account_financial_report_webkit/report/general_ledger.py
@@ -77,6 +77,9 @@ class GeneralLedgerWebkit(report_sxw.rml_parse, CommonReportHeaderWebkit):
         used by mako template"""
         lang = self.localcontext.get('lang')
         lang_ctx = lang and {'lang': lang} or {}
+
+        lang_ctx.update(self._get_customized_context(data))
+
         new_ids = data['form']['account_ids'] or data[
             'form']['chart_account_id']
 

--- a/account_financial_report_webkit/report/open_invoices.py
+++ b/account_financial_report_webkit/report/open_invoices.py
@@ -103,6 +103,9 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
            be used by mako template"""
         lang = self.localcontext.get('lang')
         lang_ctx = lang and {'lang': lang} or {}
+
+        lang_ctx.update(self._get_customized_context(data))
+
         new_ids = data['form']['chart_account_id']
         # Account initial balance memoizer
         init_balance_memoizer = {}

--- a/account_financial_report_webkit/report/open_invoices.py
+++ b/account_financial_report_webkit/report/open_invoices.py
@@ -101,6 +101,8 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
     def set_context(self, objects, data, ids, report_type=None):
         """Populate a ledger_lines attribute on each browse record that will
            be used by mako template"""
+        lang = self.localcontext.get('lang')
+        lang_ctx = lang and {'lang': lang} or {}
         new_ids = data['form']['chart_account_id']
         # Account initial balance memoizer
         init_balance_memoizer = {}
@@ -147,7 +149,8 @@ class PartnersOpenInvoicesWebkit(report_sxw.rml_parse,
             partner_filter=partner_ids)
         objects = self.pool.get('account.account').browse(self.cursor,
                                                           self.uid,
-                                                          account_ids)
+                                                          account_ids,
+                                                          context=lang_ctx)
 
         ledger_lines = {}
         init_balance = {}

--- a/account_financial_report_webkit/report/partners_ledger.py
+++ b/account_financial_report_webkit/report/partners_ledger.py
@@ -86,6 +86,8 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
     def set_context(self, objects, data, ids, report_type=None):
         """Populate a ledger_lines attribute on each browse record that will
            be used by mako template"""
+        lang = self.localcontext.get('lang')
+        lang_ctx = lang and {'lang': lang} or {}
         new_ids = data['form']['chart_account_id']
 
         # account partner memoizer
@@ -148,7 +150,8 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
             partner_filter=partner_ids)
         objects = self.pool.get('account.account').browse(self.cursor,
                                                           self.uid,
-                                                          accounts)
+                                                          accounts,
+                                                          context=lang_ctx)
 
         init_balance = {}
         ledger_lines_dict = {}

--- a/account_financial_report_webkit/report/partners_ledger.py
+++ b/account_financial_report_webkit/report/partners_ledger.py
@@ -88,6 +88,9 @@ class PartnersLedgerWebkit(report_sxw.rml_parse,
            be used by mako template"""
         lang = self.localcontext.get('lang')
         lang_ctx = lang and {'lang': lang} or {}
+
+        lang_ctx.update(self._get_customized_context(data))
+
         new_ids = data['form']['chart_account_id']
 
         # account partner memoizer


### PR DESCRIPTION
```
add a method '_get_customized_context()' in which you can add
whatever you want to the context for report calculation
Standard behaviour is to let the context unchanged
```
